### PR TITLE
Refactor audio processing and improve emulator reset logic

### DIFF
--- a/.github/workflows/BuildAndRelease.yml
+++ b/.github/workflows/BuildAndRelease.yml
@@ -36,7 +36,7 @@ jobs:
           #        sudo apt install -y cmake gcc-arm-none-eabi libnewlib-arm-none-eabi build-essential libusb-1.0-0-dev
                  
           - name: Check out this repository with submodules
-            uses: actions/checkout@v4
+            uses: actions/checkout@v6
             with:
                 submodules: recursive
           
@@ -97,7 +97,7 @@ jobs:
               cp /datalocal/upload/pico-infonesPlus/GenesisPlusMetadata.zip releases/GenesisPlusMetadata.zip
 
           - name: Create release
-            uses: softprops/action-gh-release@v2
+            uses: softprops/action-gh-release@v3
             if: startsWith(github.ref, 'refs/tags/') && github.event_name == 'push'
             with:
                 files: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *Zone.Identifier
 fh.log
+*.bin
 /pimoroni-pico/
 # Prerequisites
 *.d

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,25 @@ Only RP2350 (pico 2 based boards) supported. Works best with [Adafruit Fruit Jam
 >  
 > **Note:** This limitation does **not** apply to **HSTX-based boards** (e.g., *Adafruit Fruit Jam*), where the monitor refresh rate can be set to **60 Hz**.
 
+# v0.12 Release notes
+
+For the boards that use HSTX in stead of PicoDVI: HDMI audio is now supported via the new HSTX video driver. Huge thanks to [@fliperama86](https://github.com/fliperama86) for the awesome [pico_hdmi](https://github.com/fliperama86/pico_hdmi) driver that made this possible and for helping out.
+
+- Adafruit Fruit Jam.
+- Murmulator M2. 
+
+Other RP2350 configurations that now use HSTX (GPIO 12 - 19) in stead of PicoDVI:
+
+- [Breadboard](https://github.com/fhoedemakers/pico-infonesPlus?tab=readme-ov-file#raspberry-pi-pico-or-pico-2-setup-with-adafruit-hardware-and-breadboard)
+- [PCB](https://github.com/fhoedemakers/pico-infonesPlus?tab=readme-ov-file#pcb-with-raspberry-pi-pico-or-pico-2)
+- [Adafruit Metro RP2350](https://github.com/fhoedemakers/pico-infonesPlus?tab=readme-ov-file#adafruit-metro-rp2350)
+  
+All the other boards still use PicoDVI.
+
+To enable audio over hdmi, make sure external audio is disabled in the settings menu.
+
+- Added option in settings menu to enter bootsel mode for flashing firmware. 
+
 # v0.11 Release notes
 
 - Added support for [Murmulator M1 and M2 boards](https://murmulator.ru). [@javavi](https://github.com/javavi)  [#150](https://github.com/fhoedemakers/pico-infonesPlus/issues/150)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # CHANGELOG
 
+> HSTX improvements and SGDK games are playable now.
+
 # General Info
 
 
@@ -41,29 +43,7 @@ All the other boards still use PicoDVI.
 To enable audio over hdmi, make sure external audio is disabled in the settings menu.
 
 - Added option in settings menu to enter bootsel mode for flashing firmware. 
-
-# v0.11 Release notes
-
-- Added support for [Murmulator M1 and M2 boards](https://murmulator.ru). [@javavi](https://github.com/javavi)  [#150](https://github.com/fhoedemakers/pico-infonesPlus/issues/150)
-  - M1: RP2040/RP2350
-  - M2: RP2350 only
-  **Note**: These Murmulator M1 and M2 builds are untested. Please report any issues.
-- **Fruit Jam only**: Add volume controls to settings menu. Can also be changed in-game via (START + LEFT/RIGHT). Note that too high volume levels may cause distortion. (Ext speaker, advised 16 db max, internal advised 18 dB max). Latest metadata package includes a sample.wav file to test the volume level.
-- Updated GenesisPlusMetaData.zip: Added **sample.wav**. This sample will be played when using the Fruit Jam volume control in the settings menu. Note when **/soundrecorder.wav** is found, this file will be played in stead.
-- Updated the menu to also list .wav audio files.
-- Added basic wav audio playback from within the menu. Press BUTTON2 or START to play the wav file. Tested with https://lonepeakmusic.itch.io/retro-midi-music-pack-1 The wav file must have the following specs:
-  - 16/24 bit PCM wav files only.  (24 bit files are downsampled to 16 bit) 
-  - 2ch stereo only.
-  - Sample rate supported: 44100.
-- **RP2350 with PSRAM only**: Record about 30 seconds of audio by pressing START to pause the game and then START + BUTTON1. Audio is recorded to **/soundrecorder.wav** on the SD-card.
-
->[!NOTE]
-> Currently wav playback is too fast. 
-
-## Fixes
-
-- Fruit Jam audio fixes.
-- Settings changed by in-game button combos are saved when exiting to menu.
+- Partially fixed: Games developed with SGDK (like XenoCrisis) are now playable. However soundeffects are missing. [#11](https://github.com/fhoedemakers/pico-genesisPlus/issues/11)
 
 # previous changes
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,7 @@ target_compile_definitions(${projectname} PUBLIC
     GPIOHSTXCK=${GPIOHSTXCK} # HSTX clock pin positive
     GPIOHSTXINVERTED=${GPIOHSTXINVERTED} # Set to 1 if HSTX pins are inverted: D- = D+ -1
     ENABLE_VU_METER=${ENABLE_VU_METER} # Enable VU meter (fruitjam NeoPixel leds)
+    ENABLEDVI=1
     #DVIAUDIOFREQ=53280  # 53.28kHz audio sample rate for DVI output
 )
 if(NOT PICO_PLATFORM STREQUAL "rp2040")

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,28 @@
 # History of changes.
 
+# v0.11 Release notes
+
+- Added support for [Murmulator M1 and M2 boards](https://murmulator.ru). [@javavi](https://github.com/javavi)  [#150](https://github.com/fhoedemakers/pico-infonesPlus/issues/150)
+  - M1: RP2040/RP2350
+  - M2: RP2350 only
+  **Note**: These Murmulator M1 and M2 builds are untested. Please report any issues.
+- **Fruit Jam only**: Add volume controls to settings menu. Can also be changed in-game via (START + LEFT/RIGHT). Note that too high volume levels may cause distortion. (Ext speaker, advised 16 db max, internal advised 18 dB max). Latest metadata package includes a sample.wav file to test the volume level.
+- Updated GenesisPlusMetaData.zip: Added **sample.wav**. This sample will be played when using the Fruit Jam volume control in the settings menu. Note when **/soundrecorder.wav** is found, this file will be played in stead.
+- Updated the menu to also list .wav audio files.
+- Added basic wav audio playback from within the menu. Press BUTTON2 or START to play the wav file. Tested with https://lonepeakmusic.itch.io/retro-midi-music-pack-1 The wav file must have the following specs:
+  - 16/24 bit PCM wav files only.  (24 bit files are downsampled to 16 bit) 
+  - 2ch stereo only.
+  - Sample rate supported: 44100.
+- **RP2350 with PSRAM only**: Record about 30 seconds of audio by pressing START to pause the game and then START + BUTTON1. Audio is recorded to **/soundrecorder.wav** on the SD-card.
+
+>[!NOTE]
+> Currently wav playback is too fast. 
+
+## Fixes
+
+- Fruit Jam audio fixes.
+- Settings changed by in-game button combos are saved when exiting to menu.
+
 # v0.10 Release notes
 
 ## Features

--- a/gwenesis/bus/gwenesis_bus.c
+++ b/gwenesis/bus/gwenesis_bus.c
@@ -109,6 +109,18 @@ void load_cartridge(uintptr_t rom) {
 void power_on() {
     // Set M68K CPU as original MOTOROLA 68000
     //m68k_set_cpu_type(M68K_CPU_TYPE_68000);
+    /* Clean-slate the entire M68K core struct between game launches.
+       m68k_pulse_reset() only resets a handful of fields (PC/SP from
+       reset vectors, INT mask, supervisor flag, prefetch addr) and
+       leaves D0-D7, A0-A6, alternate SPs, NZVC flags, prefetch data,
+       instr_mode, aerr_*, idle-loop-detection state, etc. holding
+       whatever values the previous game left them in. That stale state
+       can re-enter the VBlank/exception path of the new game and send
+       PC into the vector-table region (recursive exception storm,
+       eventually overflowing host stack into a hardfault). m68ki_cycles
+       and the opcode jump tables live outside this struct, so wiping
+       it is safe; m68k_init() right after restores callbacks. */
+    memset(&m68k, 0, sizeof(m68k));
     // Initialize M68K CPU
     m68k_init();
     // Initialize Z80 CPU
@@ -138,6 +150,15 @@ void power_on() {
  *
  ******************************************************************************/
 void reset_emulation() {
+    /* Restore stale globals that previous game runs may have modified
+       (TMSS state, controller IO regs, pad state). Without this, a new
+       game's init reads back leftover values from the prior game and
+       takes a divergent execution path. */
+    tmss_state = 0;
+    tmss_count = 0;
+    memset(TMSS, 0, sizeof(TMSS));
+    gwenesis_io_reset();
+
     // Send a reset pulse to Z80 CPU
     z80_pulse_reset();
     // Send a reset pulse to Z80 M68K

--- a/gwenesis/io/gwenesis_io.c
+++ b/gwenesis/io/gwenesis_io.c
@@ -226,18 +226,24 @@ void gwenesis_io_set_reg(unsigned int reg, unsigned int value) {
     return;
 }
 
-/* Restore io_reg[] and gwenesis_io_pad_state[] to power-on defaults.
-   Without this, controller-config writes from a previous game persist
-   and change what the next game reads from $A10001/A10003/A10009 etc.,
-   causing init code to take a different branch and eventually crash. */
+/* Restore the controller side of io_reg[] and gwenesis_io_pad_state[] to
+   power-on defaults. Without this, controller-config writes from a previous
+   game persist and change what the next game reads from $A10003/A10009
+   etc., causing init code to take a different branch and eventually crash.
+
+   io_reg[0] (the version register at $A10001) is intentionally NOT reset:
+   it is set by set_region() during load_cartridge() based on the ROM's
+   region code. Overwriting it here would make every NTSC ROM read back
+   the PAL default value (0xC1) and refuse to boot ("Developed for USE
+   only with NTSC Genesis Systems"). */
 void gwenesis_io_reset(void) {
-    unsigned char defaults[16] = {GWENESIS_IO_VERSION,
-                                  0x7f, 0x7f, 0x7f,
-                                  0x00, 0x00, 0x00,
-                                  0xff,    0,    0,
-                                  0xff,    0,    0,
-                                  0xff,    0,    0};
-    memcpy(io_reg, defaults, sizeof(io_reg));
+    /* skip index 0 (version register) */
+    unsigned char defaults_from_1[15] = {0x7f, 0x7f, 0x7f,
+                                         0x00, 0x00, 0x00,
+                                         0xff,    0,    0,
+                                         0xff,    0,    0,
+                                         0xff,    0,    0};
+    memcpy(&io_reg[1], defaults_from_1, sizeof(defaults_from_1));
     gwenesis_io_pad_state[0] = 0x33;
     gwenesis_io_pad_state[1] = 0x33;
     gwenesis_io_pad_state[2] = 0x33;

--- a/gwenesis/io/gwenesis_io.c
+++ b/gwenesis/io/gwenesis_io.c
@@ -226,6 +226,24 @@ void gwenesis_io_set_reg(unsigned int reg, unsigned int value) {
     return;
 }
 
+/* Restore io_reg[] and gwenesis_io_pad_state[] to power-on defaults.
+   Without this, controller-config writes from a previous game persist
+   and change what the next game reads from $A10001/A10003/A10009 etc.,
+   causing init code to take a different branch and eventually crash. */
+void gwenesis_io_reset(void) {
+    unsigned char defaults[16] = {GWENESIS_IO_VERSION,
+                                  0x7f, 0x7f, 0x7f,
+                                  0x00, 0x00, 0x00,
+                                  0xff,    0,    0,
+                                  0xff,    0,    0,
+                                  0xff,    0,    0};
+    memcpy(io_reg, defaults, sizeof(io_reg));
+    gwenesis_io_pad_state[0] = 0x33;
+    gwenesis_io_pad_state[1] = 0x33;
+    gwenesis_io_pad_state[2] = 0x33;
+    button_state[0] = button_state[1] = button_state[2] = 0xff;
+}
+
 void gwenesis_io_save_state() {
     SaveState* state;
     state = saveGwenesisStateOpenForWrite("io");

--- a/gwenesis/io/gwenesis_io.h
+++ b/gwenesis/io/gwenesis_io.h
@@ -28,6 +28,7 @@ void gwenesis_io_write_ctrl(unsigned int address, unsigned int value);
 unsigned int gwenesis_io_read_ctrl(unsigned int address);
 
 void gwenesis_io_set_reg(unsigned int reg, unsigned int value);
+void gwenesis_io_reset(void);
 void gwenesis_io_get_buttons();
 
 void gwenesis_io_save_state();

--- a/gwenesis/sound/gwenesis_sn76489.c
+++ b/gwenesis/sound/gwenesis_sn76489.c
@@ -230,9 +230,14 @@ extern int scan_line;
 extern bool sn76489_enabled;
 
 void YM2612Update(uint16_t *buffer, int length);
+extern void ym2612_run(int target);
 
 void gwenesis_SN76489_run(int target) {
     if (sn76489_clock >= target) return;
+
+    /* Tick YM2612 timers up to the same point in master cycles. Done before
+       dividing target so ym2612_run sees raw master cycles. */
+    ym2612_run(target);
 
     target /= GWENESIS_AUDIO_SAMPLING_DIVISOR;
 

--- a/gwenesis/sound/ym2612.c
+++ b/gwenesis/sound/ym2612.c
@@ -2264,8 +2264,8 @@ void YM2612Update(int16_t* buffer, int length) {
         /* only if Timer A does not overflow again (i.e CSM Key ON not set again) */
         ym2612.OPN.SL3.key_csm <<= 1;
 
-        /* timer A control */
-        INTERNAL_TIMER_A();
+        /* Timer A/B ticks moved to ym2612_run() to keep the YM2612 status
+           register responsive to Z80 reads at sub-frame granularity. */
 
         /* CSM Mode Key ON still disabled */
         if (ym2612.OPN.SL3.key_csm & 2) {
@@ -2277,28 +2277,30 @@ void YM2612Update(int16_t* buffer, int length) {
             ym2612.OPN.SL3.key_csm = 0;
         }
     }
-
-    /* timer B control */
-    INTERNAL_TIMER_B(length);
 }
 
+/* Tracks the YM2612 sample clock (in scaled master cycles, i.e. master / GWENESIS_AUDIO_SAMPLING_DIVISOR).
+   Reset to 0 at the start of every emulator frame, alongside zclk/system_clock/sn76489_clock. */
+int ym2612_clock = 0;
+
+/* Advance YM2612 internal timers (Timer A / Timer B) up to `target` master cycles.
+   Audio sample generation is done separately by YM2612Update; this function only
+   ticks the timers so the YM2612 status register reflects timer overflows in
+   real time. SGDK's Z80 audio drivers spin on the timer-overflow status bits, so
+   without this they hang and starve the 68K → black screen lockup. */
 void ym2612_run(int target) {
-    /**
-      if ( ym2612_clock >= target) {
-        return;
-      }
+    target /= GWENESIS_AUDIO_SAMPLING_DIVISOR;
+    if (target <= ym2612_clock) return;
 
-      target /= GWENESIS_AUDIO_SAMPLING_DIVISOR;
+    int samples = (target - ym2612_clock) / ym2612.divisor;
+    if (samples <= 0) return;
 
-      int ym2612_prev_index = ym2612_index;
-      ym2612_index += (target-ym2612_clock) / ym2612.divisor;
-      if (ym2612_index > ym2612_prev_index) {
-        YM2612Update(gwenesis_sn76489_buffer + ym2612_prev_index, ym2612_index - ym2612_prev_index);
-        ym2612_clock = ym2612_index*ym2612.divisor;
+    for (int i = 0; i < samples; i++) {
+        INTERNAL_TIMER_A();
+    }
+    INTERNAL_TIMER_B(samples);
 
-      } else {
-        ym2612_index = ym2612_prev_index;
-      }*/
+    ym2612_clock += samples * ym2612.divisor;
 }
 
 unsigned char* YM2612GetContextPtr(void) {

--- a/gwenesis/sound/ym2612.h
+++ b/gwenesis/sound/ym2612.h
@@ -17,8 +17,8 @@
 #define _H_YM2612_
 
 extern int16_t *gwenesis_sn76489_buffer;
+extern int ym2612_clock;
 ///extern int ym2612_index;
-///extern int ym2612_clock;
 
 extern int snd_output_volume;
 

--- a/gwenesis/sound/z80inst.c
+++ b/gwenesis/sound/z80inst.c
@@ -144,11 +144,17 @@ void z80_write_ctrl(unsigned int address, unsigned int value) {
   } else if (address == 0x1200) // RESET
   {
     z80_log(__FUNCTION__,"RESET = %d, current=%d", value,reset);
-  
-    if (value == 0) {
-      reset = 1;
-    } else {
 
+    if (value == 0) {
+      /* Reset asserted (active low). Hold Z80 in reset. */
+      reset = 1;
+    } else if (reset) {
+      /* Edge: reset was asserted, now deasserted. Pulse the Z80 once.
+         A redundant deassert (write of non-zero while already deasserted)
+         must NOT pulse — otherwise SGDK's repeated writes to this register
+         (e.g. inside Z80_getAndRequestBus / driver-ready polling) would
+         restart the Z80 every iteration and prevent any driver from ever
+         finishing its init. */
       z80_pulse_reset();
       reset = 0;
       reset_once = 1;

--- a/gwenesis/vdp/gwenesis_vdp_mem.c
+++ b/gwenesis/vdp/gwenesis_vdp_mem.c
@@ -142,6 +142,11 @@ int m68k_irq_acked(int irq) {
 }
 
 
+extern int sprite_overflow;
+extern bool sprite_collision;
+extern int mode_pal;
+extern unsigned short fifo[FIFO_SIZE];
+
 void gwenesis_vdp_reset() {
     memset(VRAM, 0, VRAM_MAX_SIZE);
     memset(SAT_CACHE, 0, sizeof(SAT_CACHE));
@@ -149,6 +154,7 @@ void gwenesis_vdp_reset() {
     //    memset(CRAM222, 0, sizeof(CRAM222));
     memset(VSRAM, 0, sizeof(VSRAM));
     memset(gwenesis_vdp_regs, 0, sizeof(gwenesis_vdp_regs));
+    memset(fifo, 0, sizeof(unsigned short) * FIFO_SIZE);
     command_word_pending = 0;
     address_reg = 0;
     code_reg = 0;
@@ -157,6 +163,14 @@ void gwenesis_vdp_reset() {
     gwenesis_vdp_status = 0x3C00;
     // //line_counter_interrupt = 0;
     hvcounter_latched = 0;
+    /* Previously left stale across game launches. With these clear, a new
+       game's init reads consistent VDP state regardless of what the
+       previous game left behind. */
+    hvcounter_latch = 0;
+    dma_fill_pending = 0;
+    sprite_overflow = 0;
+    sprite_collision = false;
+    mode_pal = 0;
 
     // register the M68K interrupt
     m68k_set_int_ack_callback(m68k_irq_acked);

--- a/main.cpp
+++ b/main.cpp
@@ -159,7 +159,8 @@ const int8_t g_settings_visibility_md[MOPT_COUNT] = {
     0,                               // DMG Palette (Genesis emulator does not use GameBoy palettes)
     0,                               // Border Mode (Super Gameboy style borders not applicable for Genesis)
     0,                               // Rapid Fire on A (not applicable)
-    0                                // Rapid Fire on B (not applicable)
+    0,                                // Rapid Fire on B (not applicable)
+    1                                // Enter bootsel mode (moved from button combo to settings menu, but keep option visible for NES)
 
 };
 const uint8_t g_available_screen_modes_md[] = {

--- a/main.cpp
+++ b/main.cpp
@@ -159,8 +159,8 @@ const int8_t g_settings_visibility_md[MOPT_COUNT] = {
     0,                               // DMG Palette (Genesis emulator does not use GameBoy palettes)
     0,                               // Border Mode (Super Gameboy style borders not applicable for Genesis)
     0,                               // Rapid Fire on A (not applicable)
-    0,                                // Rapid Fire on B (not applicable)
-    1                                // Enter bootsel mode (moved from button combo to settings menu, but keep option visible for NES)
+    0,                               // Rapid Fire on B (not applicable)
+    1                                // Enter bootsel mode
 
 };
 const uint8_t g_available_screen_modes_md[] = {

--- a/main.cpp
+++ b/main.cpp
@@ -135,6 +135,8 @@ static uint16_t wiipad_raw_cached = 0;
  * Mitigation: Enter BOOTSEL mode before attaching the debugger at 378 MHz.
  */
 #define EMULATOR_CLOCKFREQ_KHZ 378000 //  Overclock frequency in kHz when using HSTX
+                                      // May cause artifacts on some screens, 336000 seems stable 
+                                      // https://github.com/fhoedemakers/retroJam/issues/7
 #define VOLTAGE VREG_VOLTAGE_1_60
 #endif
 // https://github.com/orgs/micropython/discussions/15722

--- a/main.cpp
+++ b/main.cpp
@@ -150,7 +150,7 @@ const int8_t g_settings_visibility_md[MOPT_COUNT] = {
     1,                               // FPS Overlay
     1,                               // Audio Enable
     1,                               // Frame Skip
-    (EXT_AUDIO_IS_ENABLED && !HSTX), // External Audio
+    (EXT_AUDIO_IS_ENABLED), // External Audio
     1,                               // Font Color
     1,                               // Font Back Color
     ENABLE_VU_METER,                 // VU Meter
@@ -618,6 +618,24 @@ static void inline processaudioPerFrameDVI()
         written += n;
     }
 }
+#else
+static void inline processaudioPerFramehstx()
+{
+    for (int i = 0; i < GWENESIS_AUDIO_BUFFER_LENGTH_NTSC * 2; i += 2)
+    {
+        int16_t l = (gwenesis_sn76489_buffer[(i) / 2 / GWENESIS_AUDIO_SAMPLING_DIVISOR]);
+        int16_t r = (gwenesis_sn76489_buffer[(i + 1) / 2 / GWENESIS_AUDIO_SAMPLING_DIVISOR]);
+        l >>= 3;
+        r >>= 3;
+        hstx_push_audio_sample(l, r);
+#if ENABLE_VU_METER
+        if (settings.flags.enableVUMeter)
+        {
+            addSampleToVUMeter(l);
+        }
+#endif
+    }
+}
 #endif
 static void inline processaudioPerFrameI2S()
 {
@@ -659,7 +677,14 @@ void inline output_audio_per_frame()
     processaudioPerFrameDVI();
 #endif
 #else
-    processaudioPerFrameI2S();
+    if (settings.flags.useExtAudio == 1)
+     {
+        processaudioPerFrameI2S();
+    }
+    else
+    {
+        processaudioPerFramehstx();
+     }
 #endif
 }
 

--- a/main.cpp
+++ b/main.cpp
@@ -663,28 +663,17 @@ void inline output_audio_per_frame()
 
     // 2. Generate all audio samples for the frame
     gwenesis_SN76489_run(target_clocks);
-#if !HSTX
 #if EXT_AUDIO_IS_ENABLED
     if (settings.flags.useExtAudio == 1)
     {
         processaudioPerFrameI2S();
+        return;
     }
-    else
-    {
-        processaudioPerFrameDVI();
-    }
-#else
-    processaudioPerFrameDVI();
 #endif
+#if !HSTX
+    processaudioPerFrameDVI();
 #else
-    if (settings.flags.useExtAudio == 1)
-     {
-        processaudioPerFrameI2S();
-    }
-    else
-    {
-        processaudioPerFramehstx();
-     }
+    processaudioPerFramehstx();
 #endif
 }
 

--- a/main.cpp
+++ b/main.cpp
@@ -44,8 +44,8 @@ static char fpsString[4] = "000";
 #define FPSSTART (((MARGINTOP + 7) / 8) * 8)
 #define FPSEND ((FPSSTART) + 8)
 
-bool reset = false;
-bool reboot = false;
+static bool reset = false;
+static bool resetGame = false;
 
 extern unsigned short button_state[3];
 // uint16_t __scratch_y("gen_palette1") palette444_1[64];
@@ -146,17 +146,19 @@ static uint32_t CPUFreqKHz = EMULATOR_CLOCKFREQ_KHZ; // 340000; //266000;
 // Order must match enum in menu_options.h
 const int8_t g_settings_visibility_md[MOPT_COUNT] = {
     0,                               // Exit Game, or back to menu. Always visible when in-game.
+    0,                               // Reset Game. Always visible when in-game.
     -1,                              // No save states/restore states for Genesis
     !HSTX,                           // Screen Mode (only when not HSTX)
     HSTX,                            // Scanlines toggle (only when HSTX)
     1,                               // FPS Overlay
     1,                               // Audio Enable
     1,                               // Frame Skip
+    (HSTX && ENABLEDVI),             // DVI Mode
     (EXT_AUDIO_IS_ENABLED), // External Audio
     1,                               // Font Color
     1,                               // Font Back Color
     ENABLE_VU_METER,                 // VU Meter
-    (HW_CONFIG == 8),                // Fruit Jam Internal Speaker
+    //(HW_CONFIG == 8),                // Fruit Jam Internal Speaker
     (HW_CONFIG == 8),                // Fruit Jam Volume Control
     0,                               // DMG Palette (Genesis emulator does not use GameBoy palettes)
     0,                               // Border Mode (Super Gameboy style borders not applicable for Genesis)
@@ -222,6 +224,7 @@ void __not_in_flash_func(processaudio)(int line)
 
 int ProcessAfterFrameIsRendered()
 {
+    Frens::pollHeadPhoneJack();
 #if NES_PIN_CLK != -1
     nespad_read_start();
 #endif
@@ -259,7 +262,12 @@ int ProcessAfterFrameIsRendered()
         abSwapped = 0;
         if (rval == 3)
         {
-            reboot = true;
+            reset = true;
+        }
+        if (rval == 5)
+        {
+            reset = true;
+            resetGame = true;
         }
         // audio_enabled may be changed from settings menu, Genesis specific
         audio_enabled = settings.flags.audioEnabled;
@@ -667,7 +675,7 @@ void inline output_audio_per_frame()
     // 2. Generate all audio samples for the frame
     gwenesis_SN76489_run(target_clocks);
 #if EXT_AUDIO_IS_ENABLED
-    if (settings.flags.useExtAudio == 1)
+    if (settings.flags.useExtAudio == 1 || Frens::isHeadPhoneJackConnected())
     {
         processaudioPerFrameI2S();
         return;
@@ -690,7 +698,7 @@ void __not_in_flash_func(emulate)()
     unsigned int old_screen_height = 0;
     char tbuf[32];
    
-    while (!reboot)
+    while (!reset)
     {
         /* Eumulator loop */
         int hint_counter = gwenesis_vdp_regs[10];
@@ -960,8 +968,6 @@ void __not_in_flash_func(emulate)()
             frame_counter++;
         }
     }
-
-    reboot = false;
 }
 
 /// @brief
@@ -1015,20 +1021,23 @@ int main()
         scaleMode8_7_ = Frens::applyScreenMode(settings.screenMode);
 #endif
 
-        reset = false;
-
-        abSwapped = 0; // don't swap A and B buttons
+        
         audio_enabled = settings.flags.audioEnabled;
-        next_frame_time = 0;  // Reset next frame time for FPS limiter
-        EXT_AUDIO_MUTE_INTERNAL_SPEAKER(settings.flags.fruitJamEnableInternalSpeaker == 0);
-        memset(palette, 0, sizeof(palette));
-        printf("Starting game\n");
-        init_emulator_mem();
-        load_cartridge(ROM_FILE_ADDR); // ROM_FILE_ADDR); // 0x100de000); // 0x100d1000);  // 0x100e2000); // ROM_FILE_ADDR);
-        power_on();
-        reset_emulation();
-        emulate();
-        free_emulator_mem();
+      
+        do {
+              abSwapped = 0; // don't swap A and B buttons
+            reset = resetGame = false; 
+            next_frame_time = 0;  // Reset next frame time for FPS limiter
+            //EXT_AUDIO_MUTE_INTERNAL_SPEAKER(settings.flags.fruitJamEnableInternalSpeaker == 0);
+            memset(palette, 0, sizeof(palette));
+            printf("Starting game\n");
+            init_emulator_mem();
+            load_cartridge(ROM_FILE_ADDR); // ROM_FILE_ADDR); // 0x100de000); // 0x100d1000);  // 0x100e2000); // ROM_FILE_ADDR);
+            power_on();
+            reset_emulation();
+            emulate();
+            free_emulator_mem();
+        } while (resetGame);
         // system_shutdown();
         selectedRom[0] = 0;
         showSplash = false;

--- a/main.cpp
+++ b/main.cpp
@@ -724,6 +724,7 @@ void __not_in_flash_func(emulate)()
         system_clock = 0;
         sn76489_clock = 0;
         sn76489_index = 0;
+        ym2612_clock = 0;
         scan_line = 0;
         if (z80_enable_mode == 1)
             z80_run(lines_per_frame * VDP_CYCLES_PER_LINE);

--- a/main.cpp
+++ b/main.cpp
@@ -697,7 +697,7 @@ void __not_in_flash_func(emulate)()
     unsigned int old_screen_width = 0;
     unsigned int old_screen_height = 0;
     char tbuf[32];
-   
+
     while (!reset)
     {
         /* Eumulator loop */
@@ -1027,13 +1027,13 @@ int main()
       
         do {
               abSwapped = 0; // don't swap A and B buttons
-            reset = resetGame = false; 
+            reset = resetGame = false;
             next_frame_time = 0;  // Reset next frame time for FPS limiter
             //EXT_AUDIO_MUTE_INTERNAL_SPEAKER(settings.flags.fruitJamEnableInternalSpeaker == 0);
             memset(palette, 0, sizeof(palette));
             printf("Starting game\n");
             init_emulator_mem();
-            load_cartridge(ROM_FILE_ADDR); // ROM_FILE_ADDR); // 0x100de000); // 0x100d1000);  // 0x100e2000); // ROM_FILE_ADDR);
+            load_cartridge(ROM_FILE_ADDR);
             power_on();
             reset_emulation();
             emulate();

--- a/splash.cpp
+++ b/splash.cpp
@@ -38,9 +38,9 @@ void splash()
     strcpy(s, "@shuichi_takano");
     putText(SCREEN_COLS / 2 - strlen(s) / 2, 14, s, CBLUE, bgcolorSplash);
 #else 
-    strcpy(s, "HSTX video driver & I2S audio");
+    strcpy(s, "HSTX video driver _ I2S audio___");
     putText(SCREEN_COLS / 2 - strlen(s) / 2, 13, s, fgcolorSplash, bgcolorSplash);
-    strcpy(s, "@frenskefrens");
+    strcpy(s, "__@fliperama86____@frenskefrens__");
     putText(SCREEN_COLS / 2 - strlen(s) / 2, 14, s, CBLUE, bgcolorSplash);
 #endif
     strcpy(s, "(S)NES/WII controller support");


### PR DESCRIPTION
This pull request introduces significant improvements to the emulator's stability and compatibility, especially for HSTX-based boards and SGDK-developed games. The most notable changes include enhanced state resets between games to prevent crashes, new support for HDMI audio via HSTX, and various workflow and documentation updates.

**Emulator stability and bug fixes:**
- Added comprehensive state resets for the M68K CPU, controller I/O, and VDP between game launches to prevent stale state from causing divergent execution paths or crashes when switching games. This includes new functions like `gwenesis_io_reset()` and additional resets in `reset_emulation()` and `gwenesis_vdp_reset()`. [[1]](diffhunk://#diff-ba7476dbe2af0aff0de0120dbcb02c1bfcb1a5d2978108af8eb4578a1e4622d1R112-R123) [[2]](diffhunk://#diff-ba7476dbe2af0aff0de0120dbcb02c1bfcb1a5d2978108af8eb4578a1e4622d1R153-R161) [[3]](diffhunk://#diff-e61e86533104089ba699a2e4be9d58eb3d758fe6f443e6a9a8c40eb51e567044R229-R252) [[4]](diffhunk://#diff-68e82f21dd680a95e0e449bc413d4fc1fd684051ef4eee9bff4200962d53db16R31) [[5]](diffhunk://#diff-a6693f2dddfad7de0c63c514576589fb47df709043786d39755dc9c912efa641R145-R157) [[6]](diffhunk://#diff-a6693f2dddfad7de0c63c514576589fb47df709043786d39755dc9c912efa641R166-R173)
- Improved Z80 reset logic to avoid repeated resets that could prevent audio drivers from initializing, addressing a key issue with SGDK-based games.

**Audio and HSTX support:**
- Added support for HDMI audio output via the HSTX video driver, making SGDK games (like XenoCrisis) playable on supported boards, though some sound effects are still missing. Also introduced an audio processing path for HSTX. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R4) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL26-R46) [[3]](diffhunk://#diff-608d8de3fba954c50110b6d7386988f27295de845e9d7174e40095ba5efcf1bbR632-R649)
- Refactored YM2612 timer handling for more accurate audio emulation and compatibility with Z80 audio drivers, crucial for SGDK game support. [[1]](diffhunk://#diff-f6d71d0c605cf3d3e3fd354552f258c4b22a9eb11ca4ee7d0a260f3760827624R233-R241) [[2]](diffhunk://#diff-f3160ed0bd76a9da669657eb726558a32d35cfcd30ac228f6f8f2d162c6fccccL2267-R2268) [[3]](diffhunk://#diff-f3160ed0bd76a9da669657eb726558a32d35cfcd30ac228f6f8f2d162c6fccccL2280-R2303) [[4]](diffhunk://#diff-095af92643368b40af633ca84f9d4c3974a5fa384d974b3e1b34bad1c6edcc92R20-L21)

**Settings and user experience:**
- Added new settings menu options, including a "Reset Game" and "Enter bootsel mode" for easier firmware flashing and in-game control. [[1]](diffhunk://#diff-608d8de3fba954c50110b6d7386988f27295de845e9d7174e40095ba5efcf1bbL47-R48) [[2]](diffhunk://#diff-608d8de3fba954c50110b6d7386988f27295de845e9d7174e40095ba5efcf1bbR149-R167) [[3]](diffhunk://#diff-608d8de3fba954c50110b6d7386988f27295de845e9d7174e40095ba5efcf1bbL259-R270)
- Updated the CPU overclock frequency for HSTX and clarified documentation.

**Build and workflow updates:**
- Updated GitHub Actions workflow dependencies to use the latest versions of checkout and release actions for improved reliability. [[1]](diffhunk://#diff-c208a9bdce5f098055be672ca5105cef2e01c5169217982d21159bbeeb647273L39-R39) [[2]](diffhunk://#diff-c208a9bdce5f098055be672ca5105cef2e01c5169217982d21159bbeeb647273L100-R100)
- Added `ENABLEDVI=1` to CMake definitions, possibly to clarify build configurations.

**Documentation:**
- Updated `CHANGELOG.md` and added `HISTORY.md` to reflect new features, fixes, and board support. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R4) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL26-R46) [[3]](diffhunk://#diff-648afe3d986261d8f2015b2b131b0e4a448d4dc6946cfde1a7a836876cee255eR3-R25)

These changes collectively improve the emulator's reliability, expand hardware support, and enhance the user experience, especially for users of HSTX-based boards and SGDK-developed games.